### PR TITLE
[READY] Packaging

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+Mark McDonnell (http://www.integralist.co.uk/)
+Addy Osmani (http://addyosmani.com/)
+Tom Maslen (http://tmaslen.com/)
+Thomas Parisot <thomas.parisot@bbc.co.uk> (https://oncletom.io/)

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "imager",
+  "main": "Imager.js",
+  "version": "0.1.0",
+  "homepage": "https://github.com/BBC-News/Imager.js",
+  "authors": [
+    "Mark McDonnell",
+    "Addy Osmani",
+    "Tom Maslen",
+    "Thomas Parisot"
+  ],
+  "description": "Imager.js is an alternative solution to the issue of how to handle responsive image loading, created by developers at BBC News.",
+  "keywords": [
+    "responsive",
+    "srcset",
+    "picturefill",
+    "polyfill",
+    "shim",
+    "img",
+    "images",
+    "web",
+    "component"
+  ],
+  "license": "Apache-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "Demo*",
+    "demos"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "Imager.js",
-  "version": "0.0.1",
+  "name": "imager",
+  "version": "0.1.0",
   "description": "Imager.js is an alternative solution to the issue of how to handle responsive image loading, created by developers at BBC News.",
-  "private": true,
   "scripts": {
     "test": "jshint Imager.js && karma start --single-run",
     "test-watch": "karma start"
@@ -21,9 +20,7 @@
     "img",
     "PictureFill"
   ],
-  "author": "Mark McDonnell, Addy Osmani",
-  "license": "Apache 2.0 open source licence",
-  "gitHead": "8d192cf0224a705e463b4dca18041168d491a6e9",
+  "license": "Apache-2.0",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-responsive-images": "0.0.3",


### PR DESCRIPTION
It makes Imager installable through `npm` and `bower`:

``` bash
npm install imager
// -> available as `node_modules/imager/Imager.js

bower install imager
// -> available as `bower_components/imager/Imager.js`
```

To be merged when:
- [ ] major parts of the refactoring are okay (constructor, `data-src` API etc.)
- [ ] README is updated
- [ ] we are ready to say it's production ready

![](http://i.imgur.com/JYFDWDz.gif)
