### PR TITLE
Changing npm package name to `imager.js` as `imager` is already taken

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Finally, it will lazy load images to speed up page load time even further.
   </thead>
   <tbody>
     <tr>
-      <td><code>npm install --save imager-js</code></td>
-      <td><code>bower install --save imager-js</code></td>
+      <td><code>npm install --save imager.js</code></td>
+      <td><code>bower install --save imager.js</code></td>
       <td><a href="https://github.com/BBC-News/Imager.js/archive/master.zip">download zip file</a></td>
     </tr>
   </tbody>

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "imager-js",
+  "name": "imager.js",
   "main": "Imager.js",
   "version": "0.1.0",
   "homepage": "https://github.com/BBC-News/Imager.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "imager-js",
+  "name": "imager.js",
   "version": "0.1.0",
   "description": "Imager.js is an alternative solution to the issue of how to handle responsive image loading, created by developers at BBC News.",
   "main": "Imager.js",


### PR DESCRIPTION
The project seems recent, and did not exist at the time we were envisioning registering it :-(

> https://npmjs.org/package/imager

We can:
- ask the owner to rename it to keep consistency
- use another package name `imager-js` or something

**Actual package name proposal**: `imager.js`
