### PR TITLE
Implementing #67

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -120,6 +120,7 @@
         this.scrolled         = false;
         this.availablePixelRatios = opts.availablePixelRatios || [1, 2];
         this.refreshPixelRatio();
+        this.widthInterpolator = opts.widthInterpolator || returnDirectValue;
 
         if (opts.availableWidths === undefined) {
             opts.availableWidths = defaultWidths;
@@ -127,7 +128,7 @@
 
         if (isArray(opts.availableWidths)) {
             this.availableWidths = opts.availableWidths;
-            this.widthsMap = Imager.createWidthsMap(this.availableWidths);
+            this.widthsMap = Imager.createWidthsMap(this.availableWidths, this.widthInterpolator);
         }
         else {
             this.availableWidths = getKeys(opts.availableWidths);
@@ -285,12 +286,12 @@
         return (context || window)['devicePixelRatio'] || 1;
     };
 
-    Imager.createWidthsMap = function createWidthsMap (widths) {
+    Imager.createWidthsMap = function createWidthsMap (widths, interpolator) {
         var map = {},
             i   = widths.length;
 
         while (i--) {
-            map[widths[i]] = null;
+            map[widths[i]] = interpolator(widths[i]);
         }
 
         return map;

--- a/README.md
+++ b/README.md
@@ -97,7 +97,28 @@ Head to this [device pixel density test](http://bjango.com/articles/min-device-p
 
 ### Interpolating `{width}` value
 
-Imager has the ability to replace `{width}` with a non-numeric value if you provide the `availableWidths` option/value in the `Object` type. This feature allows you to use a human readable name or integrate with third-party images provider.
+Imager has the ability to replace `{width}` with a non-numeric value if you
+provide the `widthInterpolator` option, which is a function that returns the
+string to be injected into the image URL for a given width. This feature allows you to use a human readable name or integrate with third-party image providers.
+
+```html
+<div style="width: 240px">
+    <div class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></div>
+</div>
+
+<script>
+    new Imager({
+        availableWidths: [200, 260, 320, 600],
+        widthInterpolator: function(width) {
+          return width + 'x' + (width/2);
+        }
+    });
+</script>
+```
+
+The `img[src]` will be computed as `http://example.com/assets/imgr-260x130.png` instead of `http://example.com/assets/imgr-260.png`.
+
+Alternatively you can define `availableWidths` as an `Object` where the key is the width, and the value is the string to be injected into the image URL.
 
 ```html
 <div style="width: 240px">

--- a/test/unit/html-options.js
+++ b/test/unit/html-options.js
@@ -62,6 +62,30 @@ describe('Imager.js HTML data-* API', function(){
         done();
       });
     });
+
+    it('should interpolate {width} based on an interpolation function', function(done){
+      fixtures = loadFixtures('data-src-interpolate');
+      var imgr = new Imager({
+        availableWidths: [320, 640, 1024],
+        widthInterpolator: function(w) {
+          if (w == 320) { return 'n_d'; }
+          if (w == 640) { return 'z_d'; }
+          return '';
+        }
+      });
+
+      runAfterAnimationFrame(function(){
+        var src = imgr.divs.map(function(el){ return el.getAttribute('src'); });
+
+        expect(src).to.eql([
+          'base/test/fixtures/interpolated/B-n_d.jpg',
+          'base/test/fixtures/interpolated/B-z_d.jpg',
+          'base/test/fixtures/1024/1024.jpg'
+        ]);
+
+        done();
+      });
+    });
   });
 
   describe('Imager.getPixelRatio', function(){


### PR DESCRIPTION
This allows the widthsMap to be dynamically created using an array of
availableWidths and a function, rather than having to build an
availableWidths object outside of Imager.

This allows you to do this:

``` html
<div class="delayed-image-load-16x9" data-src="http://ichef.bbci.co.uk/images/ic/{width}/p01mzt0r.jpg" data-alt="alt"></div>
```

``` js
new Imager('.delayed-image-load-16x9', {
    availableWidths: [160, 240, 320, 480, 560],
    widthInterpolater: function(w){ return w + 'x' + (i / (16/9)); }   
  });
```

To build a url that looks like: [http://ichef.bbci.co.uk/images/ic/**160x90**/p01mzt0r.jpg](http://ichef.bbci.co.uk/images/ic/160x90/p01mzt0r.jpg)
