### PR TITLE
[READY] Gecko Compatibility

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -268,8 +268,8 @@
             .replace(/{pixel_ratio}/g, Imager.transforms.pixelRatio(this.devicePixelRatio));
     };
 
-    Imager.getPixelRatio = function getPixelRatio(){
-        return window.devicePixelRatio || 1;
+    Imager.getPixelRatio = function getPixelRatio(context){
+        return (context || window)['devicePixelRatio'] || 1;
     };
 
     Imager.createWidthsMap = function createWidthsMap (widths) {

--- a/test/unit/html-options.js
+++ b/test/unit/html-options.js
@@ -62,6 +62,26 @@ describe('Imager.js HTML data-* API', function(){
     });
   });
 
+  describe('Imager.getPixelRatio', function(){
+      var sandbox;
+
+      beforeEach(function(){
+          sandbox = sinon.sandbox.create();
+      });
+
+      afterEach(function(){
+          sandbox.restore();
+      });
+
+      it('should return a numeric value', function(){
+        expect(Imager.getPixelRatio()).to.be.above(0);
+      });
+
+      it('should return a default value of 1 for old browser', function (){
+        expect(Imager.getPixelRatio({})).to.be.eq(1);
+      });
+  });
+
   describe('handling {pixel_ratio} in data-src', function(){
     var sandbox;
 
@@ -71,14 +91,6 @@ describe('Imager.js HTML data-* API', function(){
 
     afterEach(function(){
       sandbox.restore();
-    });
-
-    it('should always return a pixelRatio', function(){
-      expect(Imager.getPixelRatio()).to.be.above(0);
-
-      sandbox.stub(window, 'devicePixelRatio', undefined);
-      expect(window.devicePixelRatio).to.be.an('undefined');
-      expect(Imager.getPixelRatio()).to.be.eq(1);
     });
 
     it('should transform {pixel_ratio} as "" or "-<pixel ratio value>x"', function(){


### PR DESCRIPTION
This PR addresses 2 problems:
- invalid `window.devicePixelRatio` stubbing leading to failing tests
- invalid constructor argument detection leading to invalid element selection

![](http://i.imgur.com/fyxJiag.gif)
^ Hop the bugs!
