### PR TITLE
Fix #89, images not loaded when revealed by resize

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -388,6 +388,11 @@
         addEvent(window, 'scroll', function(){
             self.scrolled = true;
         });
+
+        addEvent(window, 'resize', function(){
+        	self.viewportHeight = document.documentElement.clientHeight;
+            self.scrolled = true;
+        });
     };
 
     Imager.getPageOffsetGenerator = function getPageVerticalOffset(testCase){


### PR DESCRIPTION
The problem was twofold:
1. scrollCheck did nothing, because the value of scrolled was left false.
2. Even so, The viewportHeight is set at first load and not changed, so isThisElementOnScreen would still fail if the element was below the original viewport.
