### PR TITLE
adding Imager.add method

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -27,6 +27,15 @@
       return value;
     }
 
+    function isElement (element) {
+
+        if ( typeof HTMLElement === 'object' ) {
+            return element instanceof HTMLElement;
+        }
+
+        return ( element && typeof element === "object" && element !== null && element.nodeType === 1 && typeof element.nodeName==="string" );
+    }
+
     getNaturalWidth = (function(){
         if (Object.prototype.hasOwnProperty.call(document.createElement('img'), 'naturalWidth')) {
             return function (image){ return image.naturalWidth;};
@@ -389,6 +398,18 @@
             self.scrolled = true;
         });
     };
+
+    Imager.prototype.add = function(elements) {
+        if (typeof elements === 'string') {
+            var elementsArray = applyEach(document.querySelectorAll(elements), returnDirectValue);
+            this.divs = this.divs.concat(elementsArray);
+        }
+        else if (isElement(elements)) {
+            this.divs.push(elements);
+        }
+
+        this.changeDivsToEmptyImages();
+    }
 
     Imager.getPageOffsetGenerator = function getPageVerticalOffset(testCase){
         if(testCase){

--- a/demos/default/index.html
+++ b/demos/default/index.html
@@ -55,9 +55,38 @@
           <div class="delayed-image-load" data-src="http://placehold.it/{width}" data-width="500"></div>
         </div>
 
+        <div>
+          <h2>Loading 1 image</h2>
+
+          <div class="delayed-image" data-src="http://placehold.it/{width}"><a href="#" class="load-image">Load image here</a></div>
+
+        </div>
+        
+        <div>
+          <h2>Loading multiple images</h2>
+
+          <div class="delayed-image2" data-src="http://placehold.it/{width}">
+            <a href="#" class="load-images">Load 4 more images</a>
+          </div>
+          <div class="delayed-image2" data-src="http://placehold.it/{width}"></div>
+          <div class="delayed-image2" data-src="http://placehold.it/{width}"></div>
+          <div class="delayed-image2" data-src="http://placehold.it/{width}"></div>
+        </div>
+
         <script src="../../Imager.js"></script>
         <script>
             var imager = new Imager();
+
+            var delayedImageElement = document.querySelector(".delayed-image");
+            document.querySelector(".load-image").addEventListener("click", function(event) {
+              event.preventDefault();
+              imager.add(delayedImageElement);
+            });
+
+            document.querySelector(".load-images").addEventListener("click", function(event) {
+              event.preventDefault();
+              imager.add(".delayed-image2");
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
Ability to add elements after initialization.

```
var imager = new Imager(options);
imager.add(anotherDomElement);
imager.add('.element');
```

Possible use case: loading slider images on demand.

```
var imager = new Imager(options);
var slider = new SomeSlider(options);
slider.on('slide', function(element) { imager.add(element); });
```