### PR TITLE
Fixing IE10 issues with lazy load

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -28,7 +28,7 @@
     }
 
     getNaturalWidth = (function(){
-        if (Object.prototype.hasOwnProperty.call(document.createElement('img'), 'naturalWidth')) {
+        if ('naturalWidth' in (new Image) || Object.prototype.hasOwnProperty.call(document.createElement('img'), 'naturalWidth')) {
             return function (image){ return image.naturalWidth;};
         }
         // IE8 and below lacks the naturalWidth property
@@ -286,6 +286,8 @@
         src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute('data-src'), computedWidth);
 
         image.src = src;
+        image.removeAttribute('width');
+        image.removeAttribute('height');
     };
 
     Imager.prototype.determineAppropriateResolution = function (image) {


### PR DESCRIPTION
IE10 returns undefined for naturalWidth until the image supplied in the src has loaded, rather than the 0 defined in the spec. The 'naturalWidth' in (new Image) gets around this.

It also adds a width and height to the lazy loaded images, that the this.gif.removeAttribute fix further up doesn't fix. I've removed the attributes again once the image has had its src swapped and this fixes the issue.

Lazy Loading now works in IE10.

p.s. Thanks for the script, it's been pretty useful!
