### PR TITLE
Enable IE7 Support

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -65,6 +65,23 @@
         return keys;
     };
 
+    querySelectorAll = (function(){
+        d = document,
+        s = d.createStyleSheet();
+
+        var querySelectorAll = function(r, c, i, j, a) {
+          a = d.all, c = [], r = r.replace(/\[for\b/gi, '[htmlFor').split(',');
+          for (i = r.length; i--;) {
+            s.addRule(r[i], 'k:v');
+            for (j = a.length; j--;) a[j].currentStyle.k && c.push(a[j]);
+            s.removeRule(0);
+          }
+          return c;
+        }
+
+        return querySelectorAll;
+    }());
+
 
     /*
         Construct a new Imager instance, passing an optional configuration object.
@@ -158,7 +175,7 @@
             this.selector = null;
         }
         else {
-            this.divs = applyEach(doc.querySelectorAll(this.selector), returnDirectValue);
+            this.divs = applyEach(querySelectorAll(this.selector), returnDirectValue);
         }
 
         this.changeDivsToEmptyImages();


### PR DESCRIPTION
Requirements for the project i'm currently working on changed at last minute and now include support for IE7. By changing the implementation of querySelectorAll as per - https://gist.github.com/icodeforlove/868532 Imager.js can work in IE7. Might be handy for other Developers who find themselves in a similar situation.
