### PR TITLE
Allow data-class attribute to be copied when replacing background image

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -520,7 +520,12 @@
      */
     function backgroundImageStrategy(){
         return {
-            prepareElements: noop,
+            prepareElements: function(image, elements) {
+                applyEach(elements, function(element) {
+                    var elementClassName = element.getAttribute('data-class');
+                    element.className = (elementClassName ? elementClassName + ' ' : '') + image.className;
+                });
+            },
             updateElementUrl: function(image, url){
                 image.style.backgroundImage = 'url(' + url + ')';
             },


### PR DESCRIPTION
When a div where the background image is replaced, the existing classes were not kept. 