### PR TITLE
Respect alt attribute of placeholder img

### DIFF
--- a/Imager.js
+++ b/Imager.js
@@ -247,7 +247,7 @@
 
         gif.className = (elementClassName ? elementClassName + ' ' : '') + this.className;
         gif.setAttribute('data-src', element.getAttribute('data-src'));
-        gif.setAttribute('alt', element.getAttribute('data-alt') || this.gif.alt);
+        gif.setAttribute('alt', element.getAttribute('data-alt') || element.alt || this.gif.alt);
 
         element.parentNode.replaceChild(gif, element);
 

--- a/Imager.js
+++ b/Imager.js
@@ -486,7 +486,7 @@
     Imager.addEvent = addEvent;
     Imager.debounce = debounce;
 
-    /* global module, exports: true, define */
+    /* jshint ignore:start */
     if (typeof module === 'object' && typeof module.exports === 'object') {
         // CommonJS, just export
         module.exports = exports = Imager;
@@ -497,6 +497,6 @@
         // If no AMD and we are in the browser, attach to window
         window.Imager = Imager;
     }
-    /* global -module, -exports, -define */
+    /* jshint ignore:end */
 
 }(window, document));

--- a/test/fixtures/img-placeholders.html
+++ b/test/fixtures/img-placeholders.html
@@ -1,0 +1,13 @@
+<img class="delayed-image-load" data-src="base/test/fixtures/media/A-320.jpg">
+
+<div id="main">
+  <img class="delayed-image-load" data-src="base/test/fixtures/media/A-320.jpg">
+  <img class="delayed-image-load" data-src="base/test/fixtures/media/B-320.jpg" data-alt="Responsive Image alternative" data-width="640">
+  <img class="delayed-image-load" data-src="base/test/fixtures/media/C-320.jpg" alt="Placeholder image alternative">
+
+  <span class="not-delayed-image-load">
+    <img src="data:image/gif;base64,R0lGODlhEAAJAIAAAP///wAAACH5BAEAAAAALAAAAAAQAAkAAAIKhI+py+0Po5yUFQA7" alt="Not a responsive image">
+  </span>
+</div>
+
+<img class="delayed-image-load" data-src="base/test/fixtures/media/A-320.jpg">

--- a/test/unit/html-options.js
+++ b/test/unit/html-options.js
@@ -198,6 +198,20 @@ describe('Imager.js HTML data-* API', function () {
                 done();
             });
         });
+
+        it('should honour the existing alt attribute if no data-alt attribute is available', function (done) {
+            fixtures = loadFixtures('img-placeholders');
+            var imgr = new Imager('#main .delayed-image-load');
+
+            expect(imgr.gif).to.have.property('alt', '');
+
+            imgr.ready(function () {
+                expect(imgr.divs[1]).to.have.property('alt', 'Responsive Image alternative');
+                expect(imgr.divs[2]).to.have.property('alt', 'Placeholder image alternative');
+
+                done();
+            });
+        });
     });
 
     describe('handling data-width', function () {


### PR DESCRIPTION
At BBC News, our placeholder elements are `<img>` tags. This enables us to have a custom placeholder image before Imager has run. Rather than use the `data-alt` attribute, we want to use the regular `alt` attribute so that a fallback is available for users without JavaScript (either because they disabled it or because they are on a bad connection and the JavaScript failed to download).

This PR changes Imager to honour the placeholder `alt` attribute, while still preferring `data-alt`.