### PR TITLE
Add clientWidth option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Add option to multiply width by device pixel ratio
 - Provide new set of default widths
 - Add version number information as comment to js
+- Remove code to replace divs with imgs - act on imgs directly
+- Add option to specify a target attribute instead of src
+- Add option to specify a source attribute instead of data-src
 
 ### 0.5.0 (2015/01/09 19:30 +00:00)
 - [#140](https://github.com/BBC-News/Imager.js/pull/140) Respect alt attribute of placeholder img (@wildlyinaccurate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### 0.6.0 (2018/09/13 14:30 +00:00)
+- Add option to multiply width by device pixel ratio
+
 ### 0.5.0 (2015/01/09 19:30 +00:00)
 - [#140](https://github.com/BBC-News/Imager.js/pull/140) Respect alt attribute of placeholder img (@wildlyinaccurate)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.6.0 (2018/09/13 14:30 +00:00)
 - Add option to multiply width by device pixel ratio
+- Provide new set of default widths
+- Add version number information as comment to js
 
 ### 0.5.0 (2015/01/09 19:30 +00:00)
 - [#140](https://github.com/BBC-News/Imager.js/pull/140) Respect alt attribute of placeholder img (@wildlyinaccurate)

--- a/Imager.js
+++ b/Imager.js
@@ -132,6 +132,7 @@
         this.lazyload         = opts.hasOwnProperty('lazyload') ? opts.lazyload : false;
         this.multiplyPixelRatio   = opts.hasOwnProperty('multiplyPixelRatio') ? opts.multiplyPixelRatio : true;
         this.targetAttribute       = opts.targetAttribute || 'src';
+        this.sourceAttribute       = opts.sourceAttribute || 'data-src';
         this.scrolled         = false;
         this.availablePixelRatios = opts.availablePixelRatios || [1, 2];
         this.availableWidths  = opts.availableWidths || defaultWidths;
@@ -358,7 +359,7 @@
             return;
         }
 
-        var src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute('data-src'), computedWidth);
+        var src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute(this.sourceAttribute), computedWidth);
         image.setAttribute(this.targetAttribute, src);
         image.removeAttribute('width');
         image.removeAttribute('height');

--- a/Imager.js
+++ b/Imager.js
@@ -117,6 +117,7 @@
         this.scrollDelay      = opts.scrollDelay || 250;
         this.onResize         = opts.hasOwnProperty('onResize') ? opts.onResize : true;
         this.lazyload         = opts.hasOwnProperty('lazyload') ? opts.lazyload : false;
+        this.multiplyPixelRatio   = opts.hasOwnProperty('multiplyPixelRatio') ? opts.multiplyPixelRatio : true;
         this.scrolled         = false;
         this.availablePixelRatios = opts.availablePixelRatios || [1, 2];
         this.availableWidths  = opts.availableWidths || defaultWidths;
@@ -326,7 +327,7 @@
     Imager.prototype.replaceImagesBasedOnScreenDimensions = function (image) {
         var computedWidth, naturalWidth;
 
-	naturalWidth = Imager.getNaturalWidth(image);
+    naturalWidth = Imager.getNaturalWidth(image);
         computedWidth = typeof this.availableWidths === 'function' ? this.availableWidths(image)
                                                                    : this.determineAppropriateResolution(image);
 
@@ -342,7 +343,13 @@
     };
 
     Imager.prototype.determineAppropriateResolution = function (image) {
-      return Imager.getClosestValue(image.getAttribute('data-width') || image.parentNode.clientWidth, this.availableWidths);
+        var targetWidth = image.getAttribute('data-width') || image.parentNode.clientWidth;
+        if (this.multiplyPixelRatio){
+            var pixelRatio = Imager.getPixelRatio();
+            targetWidth = targetWidth * pixelRatio;
+        }
+        console.log("target width is", targetWidth)
+      return Imager.getClosestValue(targetWidth, this.availableWidths);
     };
 
     /**

--- a/Imager.js
+++ b/Imager.js
@@ -131,6 +131,7 @@
         this.onResize         = opts.hasOwnProperty('onResize') ? opts.onResize : true;
         this.lazyload         = opts.hasOwnProperty('lazyload') ? opts.lazyload : false;
         this.multiplyPixelRatio   = opts.hasOwnProperty('multiplyPixelRatio') ? opts.multiplyPixelRatio : true;
+        this.targetAttribute       = opts.targetAttribute || 'src';
         this.scrolled         = false;
         this.availablePixelRatios = opts.availablePixelRatios || [1, 2];
         this.availableWidths  = opts.availableWidths || defaultWidths;
@@ -358,7 +359,7 @@
         }
 
         var src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute('data-src'), computedWidth);
-        image.setAttribute('src', src);
+        image.setAttribute(this.targetAttribute, src);
         image.removeAttribute('width');
         image.removeAttribute('height');
     };
@@ -501,7 +502,7 @@
         // non-HTML5 browsers workaround
         return function (image) {
             var imageCopy = document.createElement('img');
-            imageCopy.src = image.src;
+            imageCopy.src = image.targetAttribute;
             return imageCopy.width;
         };
     })();

--- a/Imager.js
+++ b/Imager.js
@@ -131,6 +131,7 @@
         this.onResize         = opts.hasOwnProperty('onResize') ? opts.onResize : true;
         this.lazyload         = opts.hasOwnProperty('lazyload') ? opts.lazyload : false;
         this.multiplyPixelRatio   = opts.hasOwnProperty('multiplyPixelRatio') ? opts.multiplyPixelRatio : true;
+        this.useClientWidth         = opts.hasOwnProperty('useClientWidth') ? opts.useClientWidth : false;
         this.targetAttribute       = opts.targetAttribute || 'src';
         this.sourceAttribute       = opts.sourceAttribute || 'data-src';
         this.scrolled         = false;
@@ -376,12 +377,15 @@
     };
 
     Imager.prototype.determineAppropriateResolution = function (image) {
-        var targetWidth = image.getAttribute('data-width') || image.parentNode.clientWidth;
+        var targetWidth;
+        if (this.useClientWidth){
+            targetWidth = document.documentElement.clientWidth;
+        }
+        else targetWidth = image.getAttribute('data-width') || image.parentNode.clientWidth;
         if (this.multiplyPixelRatio){
             var pixelRatio = Imager.getPixelRatio();
             targetWidth = targetWidth * pixelRatio;
         }
-        console.log("target width is", targetWidth)
       return Imager.getClosestValue(targetWidth, this.availableWidths);
     };
 

--- a/Imager.js
+++ b/Imager.js
@@ -1,3 +1,16 @@
+/*
+ 
+ * Imager.js
+ * v0.6.0
+
+ * Original project:
+ * https://github.com/BBC-News/Imager.js
+ *
+ * Forked by Ed Horsford:
+ * https://github.com/edwardhorsford/Imager.js
+ 
+*/
+
 ;(function (window, document) {
     'use strict';
 

--- a/Imager.js
+++ b/Imager.js
@@ -14,7 +14,7 @@
         }
     })();
 
-    var defaultWidths = [96, 130, 165, 200, 235, 270, 304, 340, 375, 410, 445, 485, 520, 555, 590, 625, 660, 695, 736];
+    var defaultWidths = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1400, 1600, 1800, 2000];
 
     var getKeys = typeof Object.keys === 'function' ? Object.keys : function (object) {
         var keys = [],

--- a/Imager.js
+++ b/Imager.js
@@ -8,7 +8,7 @@
  *
  * Forked by Ed Horsford:
  * https://github.com/edwardhorsford/Imager.js
- 
+
 */
 
 ;(function (window, document) {
@@ -175,7 +175,10 @@
 
         if (elements && elements.length) {
             var additional = applyEach(elements, returnFn);
-            this.changeDivsToEmptyImages(additional);
+            // Not sure this check is needed
+            if (this.initialized) {
+                this.checkImagesNeedReplacing(elements);
+            }
             this.divs = this.divs.concat(additional);
         }
     };
@@ -201,7 +204,11 @@
                 window.clearInterval(self.interval);
             }
 
-            this.changeDivsToEmptyImages(elements);
+            // This check might not be needed
+            if (this.initialized) {
+                this.checkImagesNeedReplacing(elements);
+            }
+
             this.scrolled = false;
         }
     };
@@ -244,41 +251,41 @@
         this.onReady = fn || noop;
     };
 
-    Imager.prototype.createGif = function (element) {
-        // if the element is already a responsive image then we don't replace it again
-        if (element.className.match(new RegExp('(^| )' + this.className + '( |$)'))) {
-            return element;
-        }
+    // Imager.prototype.createGif = function (element) {
+    //     // if the element is already a responsive image then we don't replace it again
+    //     if (element.className.match(new RegExp('(^| )' + this.className + '( |$)'))) {
+    //         return element;
+    //     }
 
-        var elementClassName = element.getAttribute('data-class');
-        var elementWidth = element.getAttribute('data-width');
-        var gif = this.gif.cloneNode(false);
+    //     var elementClassName = element.getAttribute('data-class');
+    //     var elementWidth = element.getAttribute('data-width');
+    //     var gif = this.gif.cloneNode(false);
 
-        if (elementWidth) {
-          gif.width = elementWidth;
-          gif.setAttribute('data-width', elementWidth);
-        }
+    //     if (elementWidth) {
+    //       gif.width = elementWidth;
+    //       gif.setAttribute('data-width', elementWidth);
+    //     }
 
-        gif.className = (elementClassName ? elementClassName + ' ' : '') + this.className;
-        gif.setAttribute('data-src', element.getAttribute('data-src'));
-        gif.setAttribute('alt', element.getAttribute('data-alt') || element.alt || this.gif.alt);
+    //     gif.className = (elementClassName ? elementClassName + ' ' : '') + this.className;
+    //     gif.setAttribute('data-src', element.getAttribute('data-src'));
+    //     gif.setAttribute('alt', element.getAttribute('data-alt') || element.alt || this.gif.alt);
 
-        element.parentNode.replaceChild(gif, element);
+    //     element.parentNode.replaceChild(gif, element);
 
-        return gif;
-    };
+    //     return gif;
+    // };
 
-    Imager.prototype.changeDivsToEmptyImages = function (elements) {
-        var self = this;
+    // Imager.prototype.changeDivsToEmptyImages = function (elements) {
+    //     var self = this;
 
-        applyEach(elements, function (element, i) {
-            elements[i] = self.createGif(element);
-        });
+    //     applyEach(elements, function (element, i) {
+    //         elements[i] = self.createGif(element);
+    //     });
 
-        if (this.initialized) {
-            this.checkImagesNeedReplacing(elements);
-        }
-    };
+    //     if (this.initialized) {
+    //         this.checkImagesNeedReplacing(elements);
+    //     }
+    // };
 
     /**
      * Indicates if an element is an Imager placeholder
@@ -350,7 +357,8 @@
             return;
         }
 
-        image.src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute('data-src'), computedWidth);
+        var src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute('data-src'), computedWidth);
+        image.setAttribute('src', src);
         image.removeAttribute('width');
         image.removeAttribute('height');
     };

--- a/Imager.js
+++ b/Imager.js
@@ -361,6 +361,16 @@
 
         var src = this.changeImageSrcToUseNewImageDimensions(image.getAttribute(this.sourceAttribute), computedWidth);
         image.setAttribute(this.targetAttribute, src);
+        var classSelector = this.selector;
+        if (classSelector.startsWith(".")){
+            classSelector = classSelector.substring(1);
+        }
+        if (image.classList.contains(classSelector)){
+            image.classList.remove(classSelector);
+        };
+        if (!image.classList.contains(this.className)){
+            image.classList.add(this.className);
+        };
         image.removeAttribute('width');
         image.removeAttribute('height');
     };

--- a/README.md
+++ b/README.md
@@ -46,13 +46,25 @@ npm                            | bower                            | old school
 -------------------------------|----------------------------------|------------------------------------------------------------------------------
 `npm install --save imager.js` | `bower install --save imager.js` | [download zip file](https://github.com/BBC-News/Imager.js/archive/master.zip)
 
-## Using 2018
+# Documentation
+
+Browse Imager public APIs and options – versioned alongside the source code of the project:
+
+- [HTML options](docs/html-api.md)
+- [JavaScript options](docs/js-options.md)
+- [JavaScript API](docs/js-api.md)
+
+## Notes - 2018
+
+Examples in this repo may be out of date.
+
+## Using
 
 Changes below made in 2018 by Ed Horsford
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></img>
+    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text">
 </div>
 
 <script>
@@ -83,7 +95,7 @@ in 3 different pixel ratio flavours (`1`, `1.3` and `2`):
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load" data-src="http://example.com/assets/{width}/imgr{pixel_ratio}.png" data-alt="alternative text"></img>
+    <img class="delayed-image-load" data-src="http://example.com/assets/{width}/imgr{pixel_ratio}.png" data-alt="alternative text">
 </div>
 
 <script>
@@ -107,7 +119,7 @@ string to be injected into the image URL for a given width. This feature allows 
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></img>
+    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text">
 </div>
 
 <script>
@@ -126,7 +138,7 @@ Alternatively you can define `availableWidths` as an `Object` where the key is t
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></img>
+    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text">
 </div>
 
 <script>
@@ -152,8 +164,8 @@ Here is an example to serve your own images alongside [Flickr images](http://www
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load"        data-src="http://placehold.it/{width}" data-alt="alternative text 1"></img>
-    <img class="delayed-flickr-image-load" data-src="//farm5.staticflickr.com/4148/4990539658_a38ed4ec6e_{width}.jpg" data-alt="alternative text 2"></img>
+    <img class="delayed-image-load"        data-src="http://placehold.it/{width}" data-alt="alternative text 1">
+    <img class="delayed-flickr-image-load" data-src="//farm5.staticflickr.com/4148/4990539658_a38ed4ec6e_{width}.jpg" data-alt="alternative text 2">
 </div>
 
 <script>
@@ -186,7 +198,7 @@ You might want to pass a NodeList or an array of **placeholder elements** as the
 
 ```html
 <div style="width: 240px">
-    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></img>
+    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text">
 </div>
 
 <script>
@@ -204,14 +216,6 @@ This will result in the following HTML output:
     <img src="http://placehold.it/260" data-src="http://placehold.it/{width}" alt="alternative text" class="image-replace">
 </div>
 ```
-
-# Documentation
-
-Browse Imager public APIs and options – versioned alongside the source code of the project:
-
-- [HTML options](docs/html-api.md)
-- [JavaScript options](docs/js-options.md)
-- [JavaScript API](docs/js-api.md)
 
 # Demos
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ npm                            | bower                            | old school
 -------------------------------|----------------------------------|------------------------------------------------------------------------------
 `npm install --save imager.js` | `bower install --save imager.js` | [download zip file](https://github.com/BBC-News/Imager.js/archive/master.zip)
 
+## Using 2018
 
-## Using
+Changes below made in 2018 by Ed Horsford
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></div>
+    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></img>
 </div>
 
 <script>
@@ -75,16 +76,18 @@ This will result in the following HTML output:
 
 ### Pixel Ratio / HiDPI / Retina
 
-Let's say we have generated 4 sizes of images (`200`, `260`, `320` and `600`)
+Imager will automatically multiply the width of the container by the device pixel ratio to request HiDPI images. This can be disabled by setting `multiplyPixelRatio: false`.
+
+Alternately, pixel ratio can be sent separately. Let's say we have generated 4 sizes of images (`200`, `260`, `320` and `600`)
 in 3 different pixel ratio flavours (`1`, `1.3` and `2`):
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load" data-src="http://example.com/assets/{width}/imgr{pixel_ratio}.png" data-alt="alternative text"></div>
+    <img class="delayed-image-load" data-src="http://example.com/assets/{width}/imgr{pixel_ratio}.png" data-alt="alternative text"></img>
 </div>
 
 <script>
-    new Imager({ availableWidths: [200, 260, 320, 600], availablePixelRatios: [1, 1.3, 2] });
+    new Imager({ availableWidths: [200, 260, 320, 600], availablePixelRatios: [1, 1.3, 2], multiplyPixelRatio: false });
 </script>
 ```
 
@@ -104,7 +107,7 @@ string to be injected into the image URL for a given width. This feature allows 
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></div>
+    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></img>
 </div>
 
 <script>
@@ -123,7 +126,7 @@ Alternatively you can define `availableWidths` as an `Object` where the key is t
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></div>
+    <img class="delayed-image-load" data-src="http://example.com/assets/imgr-{width}.png" data-alt="alternative text"></img>
 </div>
 
 <script>
@@ -149,8 +152,8 @@ Here is an example to serve your own images alongside [Flickr images](http://www
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load"        data-src="http://placehold.it/{width}" data-alt="alternative text 1"></div>
-    <div class="delayed-flickr-image-load" data-src="//farm5.staticflickr.com/4148/4990539658_a38ed4ec6e_{width}.jpg" data-alt="alternative text 2"></div>
+    <img class="delayed-image-load"        data-src="http://placehold.it/{width}" data-alt="alternative text 1"></img>
+    <img class="delayed-flickr-image-load" data-src="//farm5.staticflickr.com/4148/4990539658_a38ed4ec6e_{width}.jpg" data-alt="alternative text 2"></img>
 </div>
 
 <script>
@@ -183,7 +186,7 @@ You might want to pass a NodeList or an array of **placeholder elements** as the
 
 ```html
 <div style="width: 240px">
-    <div class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></div>
+    <img class="delayed-image-load" data-src="http://placehold.it/{width}" data-alt="alternative text"></img>
 </div>
 
 <script>

--- a/docs/html-api.md
+++ b/docs/html-api.md
@@ -19,7 +19,7 @@ Available placeholders are:
 So the following HTML...
 
 ```html
-<div data-src="http://placehold.it/{width}"></div>
+<img data-src="http://placehold.it/{width}"></img>
 ```
 
 ...is converted to...
@@ -38,7 +38,7 @@ So the following HTML...
 
 ```html
 <div style="width:600px">
-    <div data-src="http://placehold.it/{width}" data-width="300" data-alt="alternative text"></div>
+    <img data-src="http://placehold.it/{width}" data-width="300" data-alt="alternative text"></img>
 </div>
 ```
 
@@ -48,22 +48,4 @@ So the following HTML...
 <div style="width:600px">
     <img src="http://placehold.it/300" data-src="http://placehold.it/{width}" width="300" alt="alternative text" class="image-replace">
 </div>
-```
-
-### `data-alt` and `data-class`
-
-These two `data-*` attributes are copied from the responsive placeholder to the response `img` element.nnot process images or who have image loading disabled. It is converted to the `alt` attribute of the `img element.
-
-So the following HTML...
-
-```html
-<div data-src="http://placehold.it/{width}" data-alt="alternative text"></div>
-<div data-src="http://placehold.it/{width}" data-class="london calling"></div>
-```
-
-...is converted to...
-
-```html
-<img src="http://placehold.it/260" data-src="http://placehold.it/{width}" alt="alternative text" class="image-replace">
-<img src="http://placehold.it/260" data-src="http://placehold.it/{width}" alt="" class="london calling image-replace">
 ```

--- a/docs/html-api.md
+++ b/docs/html-api.md
@@ -19,7 +19,7 @@ Available placeholders are:
 So the following HTML...
 
 ```html
-<img data-src="http://placehold.it/{width}"></img>
+<img data-src="http://placehold.it/{width}">
 ```
 
 ...is converted to...
@@ -38,7 +38,7 @@ So the following HTML...
 
 ```html
 <div style="width:600px">
-    <img data-src="http://placehold.it/{width}" data-width="300" data-alt="alternative text"></img>
+    <img data-src="http://placehold.it/{width}" data-width="300" data-alt="alternative text">
 </div>
 ```
 

--- a/docs/js-options.md
+++ b/docs/js-options.md
@@ -133,7 +133,7 @@ An *experimental* Boolean value. If set to true, the measured width of the conta
 
 For example, with a container of 400px width and device pixel ratio of 2, the computed width will be 800px.
 
-This option should be disabled if requesting images with the `{pixel_ratio}`` placeholder.
+This option should be disabled if requesting images with the `{pixel_ratio}` placeholder.
 
 **Default value**: `true`
 
@@ -159,4 +159,14 @@ The attribute to set with the computed url. Useful if you don't want to set src 
 
 ```js
 new Imager({ targetAttribute: 'data-src-new' });
+```
+
+### `useClientWidth`
+
+Set whether Imager should use the  page width rather than `img` container width. Useful for images that are to be displayed full screen.
+
+**Default value**: `false`
+
+```js
+new Imager({ useClientWidth: true });
 ```

--- a/docs/js-options.md
+++ b/docs/js-options.md
@@ -24,6 +24,8 @@ new Imager({
 });
 ```
 
+**Default value**: `[50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1400, 1600, 1800, 2000]`
+
 `Object`: the widths associate a string value for their numeric counterpart
 
 ```js
@@ -123,4 +125,38 @@ new Imager({
         console.log('the src of all relevant images has been updated');
     }
 });
+```
+
+### `multiplyPixelRatio`
+
+An *experimental* Boolean value. If set to true, the measured width of the container will be multiplied by the device pixel ratio.
+
+For example, with a container of 400px width and device pixel ratio of 2, the computed width will be 800px.
+
+This option should be disabled if requesting images with the `{pixel_ratio}`` placeholder.
+
+**Default value**: `true`
+
+```js
+new Imager({ multiplyPixelRatio: false });
+```
+
+### `sourceAttribute`
+
+The attribute to get the src url from. Useful if `data-src` is already being used.
+
+**Default value**: `data-src`
+
+```js
+new Imager({ sourceAttribute: 'data-src-url' });
+```
+
+### `targetAttribute`
+
+The attribute to set with the computed url. Useful if you don't want to set src yet or want to do other processing.
+
+**Default value**: `src`
+
+```js
+new Imager({ targetAttribute: 'data-src-new' });
 ```


### PR DESCRIPTION
Add an option to use page width rather than container width when calculating the target size. This helps for when the target is to be displayed full-screen.